### PR TITLE
add repr to BaseCurve and timeseries objects

### DIFF
--- a/wapi/curves.py
+++ b/wapi/curves.py
@@ -30,7 +30,7 @@ class BaseCurve:
         return "{}({})".format(curve_type, name)
 
     def __repr__(self):
-        return str(self)
+        return '{}({})'.format(type(self).__name__, self.name)
 
     def _add_from_to(self, args, first, last, prefix=''):
         if first is not None:

--- a/wapi/curves.py
+++ b/wapi/curves.py
@@ -29,6 +29,9 @@ class BaseCurve:
             name = str(self.id)
         return "{}({})".format(curve_type, name)
 
+    def __repr__(self):
+        return str(self)
+
     def _add_from_to(self, args, first, last, prefix=''):
         if first is not None:
             args.append(util.make_arg('{}from'.format(prefix), first))

--- a/wapi/util.py
+++ b/wapi/util.py
@@ -92,7 +92,7 @@ class TS(object):
         return 'TS: {}{}'.format(self.fullname, size)
 
     def __repr__(self):
-        return f'TS({self.id}, {self.name})'
+        return '{}({}, {})'.format(type(self).__name__, self.id, self.name)
 
     @property
     def fullname(self):

--- a/wapi/util.py
+++ b/wapi/util.py
@@ -92,7 +92,7 @@ class TS(object):
         return 'TS: {}{}'.format(self.fullname, size)
 
     def __repr__(self):
-        return f'TS({self.id}, {self.name}, {self.frequency})'
+        return f'TS({self.id}, {self.name})'
 
     @property
     def fullname(self):

--- a/wapi/util.py
+++ b/wapi/util.py
@@ -91,6 +91,9 @@ class TS(object):
             size = ' size: {}'.format(len(self.points))
         return 'TS: {}{}'.format(self.fullname, size)
 
+    def __repr__(self):
+        return f'TS({self.id}, {self.name}, {self.frequency})'
+
     @property
     def fullname(self):
         attrs = []


### PR DESCRIPTION
I think BaseCurve should have a __repr__ to improve readability when using wapi-python interactively.