### PR TITLE
including hourly frequency to peak and off-peak data curves

### DIFF
--- a/examples/Timeseries_curve_examples/ts_filter.py
+++ b/examples/Timeseries_curve_examples/ts_filter.py
@@ -29,15 +29,18 @@ curve = session.get_curve(name=curve_name)
 data = pd.DataFrame()
 
 ## No Filter
-# read curve data from start_date to end_date to ts object
-ts15min = curve.get_data(data_from=start_date, data_to=end_date)
+# read curve data from start_date to end_date to ts object and
+# aggregate to hourly frequency
+ts15min = curve.get_data(data_from=start_date, data_to=end_date, 
+                            frequency='H', function='AVERAGE')
 # convert to pandas.Series object
 data['no filter'] = ts15min.to_pandas()
 
 ## Filter Peak Values
 # read curve data from start_date to end_date to ts object and
 # aggregate to hourly frequency
-tspeak = curve.get_data(data_from=start_date, data_to=end_date, filter='PEAK')
+tspeak = curve.get_data(data_from=start_date, data_to=end_date, 
+                            filter='PEAK', frequency='H', function='AVERAGE')
 # convert to pandas.Series object
 data['peak'] = tspeak.to_pandas()
 
@@ -45,7 +48,7 @@ data['peak'] = tspeak.to_pandas()
 # read curve data from start_date to end_date to ts object and
 # aggregate to hourly frequency
 tsoffpeak = curve.get_data(data_from=start_date, data_to=end_date,
-                           filter='OFFPEAK')
+                           filter='OFFPEAK', frequency='H', function='AVERAGE')
 # convert to pandas.Series object
 data['offpeak'] = tsoffpeak.to_pandas()
 

--- a/examples/Timeseries_curve_examples/ts_filter.py
+++ b/examples/Timeseries_curve_examples/ts_filter.py
@@ -31,10 +31,10 @@ data = pd.DataFrame()
 ## No Filter
 # read curve data from start_date to end_date to ts object and
 # aggregate to hourly frequency
-ts15min = curve.get_data(data_from=start_date, data_to=end_date, 
+tsnofilter = curve.get_data(data_from=start_date, data_to=end_date, 
                             frequency='H', function='AVERAGE')
 # convert to pandas.Series object
-data['no filter'] = ts15min.to_pandas()
+data['no filter'] = tsnofilter.to_pandas()
 
 ## Filter Peak Values
 # read curve data from start_date to end_date to ts object and

--- a/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
+++ b/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
@@ -9,10 +9,11 @@ import wapi
 import pandas as pd
 import os
 
-## INPUTS
 ################################################
 # Insert the path to your config file here!
 my_config_file = 'path/to/your/config.ini'
+################################################
+
 
 # curve names to read (in this case temperature and PV production actuals)
 curve_names = ['tt {region} con °c cet {freq} s',

--- a/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
+++ b/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
@@ -19,7 +19,7 @@ my_config_file = 'path/to/your/config.ini'
 curve_names = ['tt {region} con °c cet {freq} s',
                'pro {region} spv mwh/h cet {freq} a']
 
-#define frequency for every curve as in curve name
+# define frequency for every curve as in curve name
 freqs_curve = ['min15'] * len(curve_names)
 
 # desired freq of output, define for every curve


### PR DESCRIPTION
The peak and off-peak data curves in the `ts_filter.py` example script are supposed to contain 'hourly' frequency data; however, they currently have '15min' frequency. 

This PR changes these data to follow a hourly frequency by applying avg. aggregation.